### PR TITLE
Query optimizations, JSON slash fixes

### DIFF
--- a/src/main/java/com/kttdevelopment/myanimelist/APICall.java
+++ b/src/main/java/com/kttdevelopment/myanimelist/APICall.java
@@ -166,6 +166,7 @@ final class APICall {
             request.header(entry.getKey(), entry.getValue());
 
         request.header("Cache-Control", "no-cache, no-store, must-revalidate");
+        request.header("Accept", "application/json");
 
         if(formUrlEncoded){
             final String data = fields.isEmpty() ? "" : fields.entrySet().stream().map(e -> e.getKey() + '=' + e.getValue()).collect( Collectors.joining("&"));

--- a/src/main/java/com/kttdevelopment/myanimelist/Json.java
+++ b/src/main/java/com/kttdevelopment/myanimelist/Json.java
@@ -34,16 +34,16 @@ abstract class Json {
     private static final Pattern escBackSlash =
         Pattern.compile("\\\\\\\\");
 
-    // ^\s*(?<!\\)"(?<key>.+)(?<!\\)(?:\\\\)*": ?((?<double>-?\d+\.\d+) *,?|(?<int>-?\d+) *,?|(?<boolean>\Qtrue\E|\Qfalse\E) *,?|(?<null>\Qnull\E) *,?|(?<!\\)"(?<string>.*)(?<!\\)(?:\\\\)*" *,?|(?<array>\[)|(?<map>\{))\s*$
+    // ^\s*(?<!\\)"(?<key>.+(?<!\\)(?:\\\\)*)": ?((?<double>-?\d+\.\d+) *,?|(?<int>-?\d+) *,?|(?<boolean>\Qtrue\E|\Qfalse\E) *,?|(?<null>\Qnull\E) *,?|(?<!\\)"(?<string>.*(?<!\\)(?:\\\\)*)" *,?|(?<array>\[)|(?<map>\{))\s*$
     private static final Pattern mapType =
-        Pattern.compile("^\\s*(?<!\\\\)\"(?<key>.+)(?<!\\\\)(?:\\\\\\\\)*\": ?((?<double>-?\\d+\\.\\d+) *,?|(?<int>-?\\d+) *,?|(?<boolean>\\Qtrue\\E|\\Qfalse\\E) *,?|(?<null>\\Qnull\\E) *,?|(?<!\\\\)\"(?<string>.*)(?<!\\\\)(?:\\\\\\\\)*\" *,?|(?<array>\\[)|(?<map>\\{))\\s*$");
+        Pattern.compile("^\\s*(?<!\\\\)\"(?<key>.+(?<!\\\\)(?:\\\\\\\\)*)\": ?((?<double>-?\\d+\\.\\d+) *,?|(?<int>-?\\d+) *,?|(?<boolean>\\Qtrue\\E|\\Qfalse\\E) *,?|(?<null>\\Qnull\\E) *,?|(?<!\\\\)\"(?<string>.*(?<!\\\\)(?:\\\\\\\\)*)\" *,?|(?<array>\\[)|(?<map>\\{))\\s*$");
     // ^\s*} *,?\s*$
     private static final Pattern mapClose =
         Pattern.compile("^\\s*} *,?\\s*$");
 
-    // ^\s*((?<double>-?\d+\.\d+) *,?|(?<int>-?\d+) *,?|(?<boolean>\Qtrue\E|\Qfalse\E) *,?|(?<null>\Qnull\E) *,?|(?<!\\)"(?<string>.*)(?<!\\)(?:\\\\)*" *,?|(?<array>\[)|(?<map>\{))\s*$
+    // ^\s*((?<double>-?\d+\.\d+) *,?|(?<int>-?\d+) *,?|(?<boolean>\Qtrue\E|\Qfalse\E) *,?|(?<null>\Qnull\E) *,?|(?<!\\)"(?<string>.*(?<!\\)(?:\\\\)*)" *,?|(?<array>\[)|(?<map>\{))\s*$
     private static final Pattern arrType =
-        Pattern.compile("^\\s*((?<double>-?\\d+\\.\\d+) *,?|(?<int>-?\\d+) *,?|(?<boolean>\\Qtrue\\E|\\Qfalse\\E) *,?|(?<null>\\Qnull\\E) *,?|(?<!\\\\)\"(?<string>.*)(?<!\\\\)(?:\\\\\\\\)*\" *,?|(?<array>\\[)|(?<map>\\{))\\s*$");
+        Pattern.compile("^\\s*((?<double>-?\\d+\\.\\d+) *,?|(?<int>-?\\d+) *,?|(?<boolean>\\Qtrue\\E|\\Qfalse\\E) *,?|(?<null>\\Qnull\\E) *,?|(?<!\\\\)\"(?<string>.*(?<!\\\\)(?:\\\\\\\\)*)\" *,?|(?<array>\\[)|(?<map>\\{))\\s*$");
 
     // ^\s*] *,?\s*$
     private static final Pattern arrClose =
@@ -66,7 +66,7 @@ abstract class Json {
         final Matcher matcher = split.matcher(json);
         final Matcher quotes = nonEscQuote.matcher("");
         while(matcher.find()){ // while still contains line splitting symbol
-            final int index = matcher.start();
+            final int index = matcher.end() - 1; // before the comma/split character
             final String after = json.substring(index + 1);
             final long count = quotes.reset(after).results().count();
             if(count %2 == 0){ // even means symbol is not within quotes
@@ -143,7 +143,7 @@ abstract class Json {
                                 escQuoteMatcher.reset(raw)
                                 .replaceAll("\""))
                             .replaceAll("/"))
-                        .replaceAll("\\")
+                        .replaceAll("\\\\")
                     );
                 else if(matcher.group("array") != null) // open new array
                     list.add(openArray(reader));
@@ -174,7 +174,7 @@ abstract class Json {
                             escQuoteMatcher.reset(matcher.group("key"))
                             .replaceAll("\""))
                         .replaceAll("/"))
-                    .replaceAll("\\");
+                    .replaceAll("\\\\");
                 String raw;
                 if((raw = matcher.group("double")) != null)
                     try{
@@ -200,7 +200,7 @@ abstract class Json {
                                 escQuoteMatcher.reset(raw)
                                 .replaceAll("\""))
                             .replaceAll("/"))
-                        .replaceAll("\\")
+                        .replaceAll("\\\\")
                     );
                 else if(matcher.group("array") != null) // open new array
                     obj.set(key, openArray(reader));

--- a/src/main/java/com/kttdevelopment/myanimelist/Json.java
+++ b/src/main/java/com/kttdevelopment/myanimelist/Json.java
@@ -19,23 +19,31 @@ abstract class Json {
     // [\{\}\[\],]
     private static final Pattern split = Pattern.compile("[{}\\[\\],]");
 
-    // (?<!\\)"
-    private static final Pattern nonEscQuote = Pattern.compile("(?<!\\\\)\"");
+    // (?<!\\)(?:\\\\)*"
+    private static final Pattern nonEscQuote = Pattern.compile("(?<!\\\\)(?:\\\\\\\\)*\"");
 
     // \\"
     private static final Pattern escQuote =
         Pattern.compile("\\\\\"");
 
-    // ^\s*(?<!\\)"(?<key>.+)(?<!\\)": ?((?<double>-?\d+\.\d+) *,?|(?<int>-?\d+) *,?|(?<boolean>\Qtrue\E|\Qfalse\E) *,?|(?<null>\Qnull\E) *,?|(?<!\\)"(?<string>.*)(?<!\\)" *,?|(?<array>\[)|(?<map>\{))\s*$
+    // \\\/
+    private static final Pattern escFwdSlash =
+        Pattern.compile("\\\\/");
+
+    // \\\\
+    private static final Pattern escBackSlash =
+        Pattern.compile("\\\\\\\\");
+
+    // ^\s*(?<!\\)"(?<key>.+)(?<!\\)(?:\\\\)*": ?((?<double>-?\d+\.\d+) *,?|(?<int>-?\d+) *,?|(?<boolean>\Qtrue\E|\Qfalse\E) *,?|(?<null>\Qnull\E) *,?|(?<!\\)"(?<string>.*)(?<!\\)(?:\\\\)*" *,?|(?<array>\[)|(?<map>\{))\s*$
     private static final Pattern mapType =
-        Pattern.compile("^\\s*(?<!\\\\)\"(?<key>.+)(?<!\\\\)\": ?((?<double>-?\\d+\\.\\d+) *,?|(?<int>-?\\d+) *,?|(?<boolean>\\Qtrue\\E|\\Qfalse\\E) *,?|(?<null>\\Qnull\\E) *,?|(?<!\\\\)\"(?<string>.*)(?<!\\\\)\" *,?|(?<array>\\[)|(?<map>\\{))\\s*$");
+        Pattern.compile("^\\s*(?<!\\\\)\"(?<key>.+)(?<!\\\\)(?:\\\\\\\\)*\": ?((?<double>-?\\d+\\.\\d+) *,?|(?<int>-?\\d+) *,?|(?<boolean>\\Qtrue\\E|\\Qfalse\\E) *,?|(?<null>\\Qnull\\E) *,?|(?<!\\\\)\"(?<string>.*)(?<!\\\\)(?:\\\\\\\\)*\" *,?|(?<array>\\[)|(?<map>\\{))\\s*$");
     // ^\s*} *,?\s*$
     private static final Pattern mapClose =
         Pattern.compile("^\\s*} *,?\\s*$");
 
-    // ^\s*((?<double>-?\d+\.\d+) *,?|(?<int>-?\d+) *,?|(?<boolean>\Qtrue\E|\Qfalse\E) *,?|(?<null>\Qnull\E) *,?|(?<!\\)"(?<string>.*)(?<!\\)" *,?|(?<array>\[)|(?<map>\{))\s*$
+    // ^\s*((?<double>-?\d+\.\d+) *,?|(?<int>-?\d+) *,?|(?<boolean>\Qtrue\E|\Qfalse\E) *,?|(?<null>\Qnull\E) *,?|(?<!\\)"(?<string>.*)(?<!\\)(?:\\\\)*" *,?|(?<array>\[)|(?<map>\{))\s*$
     private static final Pattern arrType =
-        Pattern.compile("^\\s*((?<double>-?\\d+\\.\\d+) *,?|(?<int>-?\\d+) *,?|(?<boolean>\\Qtrue\\E|\\Qfalse\\E) *,?|(?<null>\\Qnull\\E) *,?|(?<!\\\\)\"(?<string>.*)(?<!\\\\)\" *,?|(?<array>\\[)|(?<map>\\{))\\s*$");
+        Pattern.compile("^\\s*((?<double>-?\\d+\\.\\d+) *,?|(?<int>-?\\d+) *,?|(?<boolean>\\Qtrue\\E|\\Qfalse\\E) *,?|(?<null>\\Qnull\\E) *,?|(?<!\\\\)\"(?<string>.*)(?<!\\\\)(?:\\\\\\\\)*\" *,?|(?<array>\\[)|(?<map>\\{))\\s*$");
 
     // ^\s*] *,?\s*$
     private static final Pattern arrClose =
@@ -102,7 +110,10 @@ abstract class Json {
 
     private static List<?> openArray(final BufferedReader reader) throws IOException{
         final Matcher matcher = arrType.matcher("");
-        final Matcher strMatcher = escQuote.matcher("");
+        final Matcher escQuoteMatcher = escQuote.matcher("");
+        final Matcher escFwdSlashMatcher = escFwdSlash.matcher("");
+        final Matcher escBackSlashMatcher = escBackSlash.matcher("");
+
         final List<Object> list = new ArrayList<>();
         String ln;
         while((ln = reader.readLine()) != null){ // while not closing tag
@@ -126,7 +137,14 @@ abstract class Json {
                 else if(matcher.group("null") != null)
                     list.add(null);
                 else if((raw = matcher.group("string")) != null)
-                    list.add(strMatcher.reset(raw).replaceAll("\""));
+                    list.add(
+                        escBackSlashMatcher.reset(
+                            escFwdSlashMatcher.reset(
+                                escQuoteMatcher.reset(raw)
+                                .replaceAll("\""))
+                            .replaceAll("/"))
+                        .replaceAll("\\")
+                    );
                 else if(matcher.group("array") != null) // open new array
                     list.add(openArray(reader));
                 else if(matcher.group("map") != null) // open new map
@@ -141,13 +159,22 @@ abstract class Json {
 
     private static JsonObject openMap(final BufferedReader reader) throws IOException{
         final Matcher matcher = mapType.matcher("");
-        final Matcher strMatcher = escQuote.matcher("");
+        final Matcher escQuoteMatcher = escQuote.matcher("");
+        final Matcher escFwdSlashMatcher = escFwdSlash.matcher("");
+        final Matcher escBackSlashMatcher = escBackSlash.matcher("");
+
         final JsonObject obj = new JsonObject();
         String ln;
         while((ln = reader.readLine()) != null){
             ln = ln.trim();
             if(matcher.reset(ln).matches()){
-                final String key = strMatcher.reset(matcher.group("key")).replaceAll("\"");
+                final String key =
+                    escBackSlashMatcher.reset(
+                        escFwdSlashMatcher.reset(
+                            escQuoteMatcher.reset(matcher.group("key"))
+                            .replaceAll("\""))
+                        .replaceAll("/"))
+                    .replaceAll("\\");
                 String raw;
                 if((raw = matcher.group("double")) != null)
                     try{
@@ -166,7 +193,15 @@ abstract class Json {
                 else if(matcher.group("null") != null)
                     obj.set(key, null);
                 else if((raw = matcher.group("string")) != null)
-                    obj.set(key, strMatcher.reset(raw).replaceAll("\""));
+                    obj.set(
+                        key,
+                        escBackSlashMatcher.reset(
+                            escFwdSlashMatcher.reset(
+                                escQuoteMatcher.reset(raw)
+                                .replaceAll("\""))
+                            .replaceAll("/"))
+                        .replaceAll("\\")
+                    );
                 else if(matcher.group("array") != null) // open new array
                     obj.set(key, openArray(reader));
                 else if(matcher.group("map") != null) // open new map

--- a/src/main/java/com/kttdevelopment/myanimelist/MyAnimeListImpl.java
+++ b/src/main/java/com/kttdevelopment/myanimelist/MyAnimeListImpl.java
@@ -68,7 +68,7 @@ final class MyAnimeListImpl extends MyAnimeList{
         return new AnimeSearchQuery(service) {
 
             @Override
-            public final List<AnimePreview> search(){
+            public final List<Anime> search(){
                 final JsonObject response = handleResponse(
                     () -> service.getAnime(
                         auth,
@@ -80,14 +80,14 @@ final class MyAnimeListImpl extends MyAnimeList{
                 );
                 if(response == null) return null;
 
-                final List<AnimePreview> anime = new ArrayList<>();
+                final List<Anime> anime = new ArrayList<>();
                 for(final JsonObject iterator : response.getJsonArray("data"))
-                    anime.add(asAnimePreview(MyAnimeListImpl.this, iterator.getJsonObject("node")));
+                    anime.add(asAnime(MyAnimeListImpl.this, iterator.getJsonObject("node")));
                 return anime;
             }
 
             @Override
-            public final PaginatedIterator<AnimePreview> searchAll(){
+            public final PaginatedIterator<Anime> searchAll(){
                 return new PaginatedIterator<>() {
 
                     private final AtomicInteger current = new AtomicInteger(-limit); // make so first nextPage returns offset 0
@@ -114,7 +114,7 @@ final class MyAnimeListImpl extends MyAnimeList{
                     }
 
                     @Override
-                    synchronized final List<AnimePreview> getNextPage(){
+                    synchronized final List<Anime> getNextPage(){
                         final AnimeSearchQuery asq = getAnime()
                             .withQuery(query)
                             .withLimit(limit)
@@ -210,7 +210,7 @@ final class MyAnimeListImpl extends MyAnimeList{
         return new AnimeSeasonQuery(service, year, Objects.requireNonNull(season)) {
 
             @Override
-            public final List<AnimePreview> search(){
+            public final List<Anime> search(){
                 final JsonObject response = handleResponse(
                     () -> service.getAnimeSeason(
                         auth,
@@ -224,14 +224,14 @@ final class MyAnimeListImpl extends MyAnimeList{
                 );
                 if(response == null) return null;
 
-                final List<AnimePreview> anime = new ArrayList<>();
+                final List<Anime> anime = new ArrayList<>();
                 for(final JsonObject iterator : response.getJsonArray("data"))
-                    anime.add(asAnimePreview(MyAnimeListImpl.this, iterator.getJsonObject("node")));
+                    anime.add(asAnime(MyAnimeListImpl.this, iterator.getJsonObject("node")));
                 return anime;
             }
 
             @Override
-            public final PaginatedIterator<AnimePreview> searchAll(){
+            public final PaginatedIterator<Anime> searchAll(){
                 return new PaginatedIterator<>() {
 
                     private final AtomicInteger current = new AtomicInteger(-limit); // make so first nextPage returns offset 0
@@ -253,7 +253,7 @@ final class MyAnimeListImpl extends MyAnimeList{
                     }
 
                     @Override
-                    synchronized final List<AnimePreview> getNextPage(){
+                    synchronized final List<Anime> getNextPage(){
                         final AnimeSeasonQuery asq = getAnimeSeason(year, season)
                             .sortBy(sort)
                             .withLimit(limit)
@@ -275,7 +275,7 @@ final class MyAnimeListImpl extends MyAnimeList{
         return new AnimeSuggestionQuery(service) {
 
             @Override
-            public final List<AnimePreview> search(){
+            public final List<Anime> search(){
                 final JsonObject response = handleResponse(
                     () -> service.getAnimeSuggestions(
                         auth,
@@ -286,14 +286,14 @@ final class MyAnimeListImpl extends MyAnimeList{
                 );
                 if(response == null) return null;
 
-                final List<AnimePreview> anime = new ArrayList<>();
+                final List<Anime> anime = new ArrayList<>();
                 for(final JsonObject iterator : response.getJsonArray("data"))
-                    anime.add(asAnimePreview(MyAnimeListImpl.this, iterator.getJsonObject("node")));
+                    anime.add(asAnime(MyAnimeListImpl.this, iterator.getJsonObject("node")));
                 return anime;
             }
 
             @Override
-            public final PaginatedIterator<AnimePreview> searchAll(){
+            public final PaginatedIterator<Anime> searchAll(){
                 return new PaginatedIterator<>() {
 
                     private final AtomicInteger current = new AtomicInteger(-limit); // make so first nextPage returns offset 0
@@ -312,7 +312,7 @@ final class MyAnimeListImpl extends MyAnimeList{
                     }
 
                     @Override
-                    synchronized final List<AnimePreview> getNextPage(){
+                    synchronized final List<Anime> getNextPage(){
                         final AnimeSuggestionQuery asq = getAnimeSuggestions()
                             .withLimit(limit)
                             .withOffset(current.addAndGet(between(0, limit, 100)))
@@ -545,7 +545,7 @@ final class MyAnimeListImpl extends MyAnimeList{
         return new MangaSearchQuery(service) {
 
             @Override
-            public final List<MangaPreview> search(){
+            public final List<Manga> search(){
                 final JsonObject response = handleResponse(
                     () -> service.getManga(
                         auth,
@@ -557,14 +557,14 @@ final class MyAnimeListImpl extends MyAnimeList{
                 );
                 if(response == null) return null;
 
-                final List<MangaPreview> manga = new ArrayList<>();
+                final List<Manga> manga = new ArrayList<>();
                 for(final JsonObject iterator : response.getJsonArray("data"))
-                    manga.add(asMangaPreview(MyAnimeListImpl.this, iterator.getJsonObject("node")));
+                    manga.add(asManga(MyAnimeListImpl.this, iterator.getJsonObject("node")));
                 return manga;
             }
 
             @Override
-            public final PaginatedIterator<MangaPreview> searchAll(){
+            public final PaginatedIterator<Manga> searchAll(){
                 return new PaginatedIterator<>() {
 
                     private final AtomicInteger current = new AtomicInteger(-limit); // make so first nextPage returns offset 0
@@ -584,7 +584,7 @@ final class MyAnimeListImpl extends MyAnimeList{
                     }
 
                     @Override
-                    synchronized final List<MangaPreview> getNextPage(){
+                    synchronized final List<Manga> getNextPage(){
                         final MangaSearchQuery msq = getManga()
                             .withQuery(query)
                             .withLimit(limit)

--- a/src/main/java/com/kttdevelopment/myanimelist/MyAnimeListImpl.java
+++ b/src/main/java/com/kttdevelopment/myanimelist/MyAnimeListImpl.java
@@ -64,7 +64,7 @@ final class MyAnimeListImpl extends MyAnimeList{
 
     @Override
     public final AnimeSearchQuery getAnime(){
-        return new AnimeSearchQuery(service) {
+        return new AnimeSearchQuery() {
 
             @Override
             public final List<Anime> search(){
@@ -159,7 +159,7 @@ final class MyAnimeListImpl extends MyAnimeList{
 
     @Override
     public final AnimeRankingQuery getAnimeRanking(final AnimeRankingType rankingType){
-        return new AnimeRankingQuery(service, Objects.requireNonNull(rankingType)) {
+        return new AnimeRankingQuery(Objects.requireNonNull(rankingType)) {
 
             @Override
             public final List<AnimeRanking> search(){
@@ -238,7 +238,7 @@ final class MyAnimeListImpl extends MyAnimeList{
 
     @Override
     public final AnimeSeasonQuery getAnimeSeason(final int year, final Season season){
-        return new AnimeSeasonQuery(service, year, Objects.requireNonNull(season)) {
+        return new AnimeSeasonQuery(year, Objects.requireNonNull(season)) {
 
             @Override
             public final List<Anime> search(){
@@ -324,7 +324,7 @@ final class MyAnimeListImpl extends MyAnimeList{
 
     @Override
     public final AnimeSuggestionQuery getAnimeSuggestions(){
-        return new AnimeSuggestionQuery(service) {
+        return new AnimeSuggestionQuery() {
 
             @Override
             public final List<Anime> search(){
@@ -401,7 +401,7 @@ final class MyAnimeListImpl extends MyAnimeList{
 
     @Override
     public final AnimeListUpdate updateAnimeListing(final long id){
-        return new AnimeListUpdate(service, id) {
+        return new AnimeListUpdate(id) {
 
             @Override
             public synchronized final AnimeListStatus update(){
@@ -443,7 +443,7 @@ final class MyAnimeListImpl extends MyAnimeList{
 
     @Override
     public final UserAnimeListQuery getUserAnimeListing(final String username){
-        return new UserAnimeListQuery(service, Objects.requireNonNull(username)) {
+        return new UserAnimeListQuery(Objects.requireNonNull(username)) {
 
             @Override
             public final List<AnimeListStatus> search(){
@@ -564,7 +564,7 @@ final class MyAnimeListImpl extends MyAnimeList{
 
     @Override
     public final ForumSearchQuery getForumTopics(){
-        return new ForumSearchQuery(service) {
+        return new ForumSearchQuery() {
 
             @Override
             public final List<ForumTopicDetail> search(){
@@ -655,7 +655,7 @@ final class MyAnimeListImpl extends MyAnimeList{
 
     @Override
     public final MangaSearchQuery getManga(){
-        return new MangaSearchQuery(service) {
+        return new MangaSearchQuery() {
 
             @Override
             public final List<Manga> search(){
@@ -751,7 +751,7 @@ final class MyAnimeListImpl extends MyAnimeList{
 
     @Override
     public final MangaRankingQuery getMangaRanking(final MangaRankingType rankingType){
-        return new MangaRankingQuery(service, Objects.requireNonNull(rankingType)) {
+        return new MangaRankingQuery(Objects.requireNonNull(rankingType)) {
 
             @Override
             public final List<MangaRanking> search(){
@@ -831,7 +831,7 @@ final class MyAnimeListImpl extends MyAnimeList{
 
     @Override
     public final MangaListUpdate updateMangaListing(final long id){
-        return new MangaListUpdate(service, id) {
+        return new MangaListUpdate(id) {
 
             @Override
             public synchronized final MangaListStatus update(){
@@ -874,7 +874,7 @@ final class MyAnimeListImpl extends MyAnimeList{
 
     @Override
     public final UserMangaListQuery getUserMangaListing(final String username){
-        return new UserMangaListQuery(service, Objects.requireNonNull(username)) {
+        return new UserMangaListQuery(Objects.requireNonNull(username)) {
 
             @Override
             public final List<MangaListStatus> search(){

--- a/src/main/java/com/kttdevelopment/myanimelist/MyAnimeListService.java
+++ b/src/main/java/com/kttdevelopment/myanimelist/MyAnimeListService.java
@@ -13,7 +13,7 @@ import static com.kttdevelopment.myanimelist.Json.*;
  * @author Ktt Development
  */
 @SuppressWarnings({"DefaultAnnotationParam", "ClassEscapesDefinedScope"})
-public interface MyAnimeListService {
+interface MyAnimeListService {
 
     String baseURL = "https://api.myanimelist.net/v2/";
 
@@ -35,9 +35,9 @@ public interface MyAnimeListService {
 
     @Endpoint(method="GET", value="anime/{anime_id}")
     Response<JsonObject> getAnime(
-        @Header("Authorization")                   final String token,
-        @Path(value = "anime_id")                  final Long anime_id,
-        @Query(value = "fields", encoded = true)   final String fields
+        @Header("Authorization")                    final String token,
+        @Path(value = "anime_id")                   final Long anime_id,
+        @Query(value = "fields", encoded = true)    final String fields
     );
 
     @Endpoint(method="GET", value="anime/ranking")
@@ -126,15 +126,15 @@ public interface MyAnimeListService {
     @SuppressWarnings("SpellCheckingInspection")
     @Endpoint(method="GET", value="forum/topics")
     Response<JsonObject> getForumTopics(
-        @Header("Authorization")   final String token,
-        @Query("board_id")          final Long board_id,
-        @Query("subboard_id")       final Long subboard_id,
-        @Query("limit")             final Integer limit,
-        @Query("offset")            final Integer offset,
-        @Query("sort")              final String sort,
-        @Query("q")                 final String search,
-        @Query("topic_user_name")   final String topic_username,
-        @Query("user_name")         final String username
+        @Header("Authorization")                    final String token,
+        @Query("board_id")                          final Long board_id,
+        @Query("subboard_id")                       final Long subboard_id,
+        @Query("limit")                             final Integer limit,
+        @Query("offset")                            final Integer offset,
+        @Query("sort")                              final String sort,
+        @Query("q")                                 final String search,
+        @Query("topic_user_name")                   final String topic_username,
+        @Query("user_name")                         final String username
     );
 
     // manga

--- a/src/main/java/com/kttdevelopment/myanimelist/MyAnimeListService.java
+++ b/src/main/java/com/kttdevelopment/myanimelist/MyAnimeListService.java
@@ -12,7 +12,7 @@ import static com.kttdevelopment.myanimelist.Json.*;
  * @version 1.0.0
  * @author Ktt Development
  */
-@SuppressWarnings({"DefaultAnnotationParam", "ClassEscapesDefinedScope"})
+@SuppressWarnings("DefaultAnnotationParam")
 interface MyAnimeListService {
 
     String baseURL = "https://api.myanimelist.net/v2/";

--- a/src/main/java/com/kttdevelopment/myanimelist/query/AnimeListUpdate.java
+++ b/src/main/java/com/kttdevelopment/myanimelist/query/AnimeListUpdate.java
@@ -1,6 +1,5 @@
 package com.kttdevelopment.myanimelist.query;
 
-import com.kttdevelopment.myanimelist.MyAnimeListService;
 import com.kttdevelopment.myanimelist.anime.AnimeListStatus;
 import com.kttdevelopment.myanimelist.anime.property.AnimeStatus;
 import com.kttdevelopment.myanimelist.query.property.RewatchValue;
@@ -25,14 +24,13 @@ public abstract class AnimeListUpdate extends ListUpdate<AnimeListUpdate,AnimeLi
     /**
      * Creates an Anime list update. Applications do not use this constructor.
      *
-     * @param service MyAnimeList
      * @param id Anime id
      *
      * @see com.kttdevelopment.myanimelist.MyAnimeList#updateAnimeListing(long)
      * @since 1.0.0
      */
-    public AnimeListUpdate(final MyAnimeListService service, final long id){
-        super(service, id);
+    public AnimeListUpdate(final long id){
+        super(id);
     }
 
     /**

--- a/src/main/java/com/kttdevelopment/myanimelist/query/AnimeRankingQuery.java
+++ b/src/main/java/com/kttdevelopment/myanimelist/query/AnimeRankingQuery.java
@@ -1,6 +1,5 @@
 package com.kttdevelopment.myanimelist.query;
 
-import com.kttdevelopment.myanimelist.MyAnimeListService;
 import com.kttdevelopment.myanimelist.anime.AnimeRanking;
 import com.kttdevelopment.myanimelist.anime.property.AnimeRankingType;
 
@@ -22,15 +21,13 @@ public abstract class AnimeRankingQuery extends FieldSearchQuery<AnimeRankingQue
     /**
      * Creates an Anime ranking query. Applications do not use this constructor.
      *
-     * @param service MyAnimeList
      * @param rankingType ranking type
      *
      * @see com.kttdevelopment.myanimelist.MyAnimeList#getAnimeRanking(AnimeRankingType)
      * @see AnimeRankingType
      * @since 1.0.0
      */
-    public AnimeRankingQuery(final MyAnimeListService service, final AnimeRankingType rankingType) {
-        super(service);
+    public AnimeRankingQuery(final AnimeRankingType rankingType) {
         this.rankingType = rankingType;
     }
 

--- a/src/main/java/com/kttdevelopment/myanimelist/query/AnimeSearchQuery.java
+++ b/src/main/java/com/kttdevelopment/myanimelist/query/AnimeSearchQuery.java
@@ -2,6 +2,7 @@ package com.kttdevelopment.myanimelist.query;
 
 import com.kttdevelopment.myanimelist.MyAnimeList;
 import com.kttdevelopment.myanimelist.MyAnimeListService;
+import com.kttdevelopment.myanimelist.anime.Anime;
 import com.kttdevelopment.myanimelist.anime.AnimePreview;
 
 /**
@@ -14,7 +15,7 @@ import com.kttdevelopment.myanimelist.anime.AnimePreview;
  * @version 1.0.0
  * @author Ktt Development
  */
-public abstract class AnimeSearchQuery extends FieldSearchQuery<AnimeSearchQuery,AnimePreview> {
+public abstract class AnimeSearchQuery extends FieldSearchQuery<AnimeSearchQuery,Anime> {
 
     protected String query;
     protected Boolean nsfw;

--- a/src/main/java/com/kttdevelopment/myanimelist/query/AnimeSearchQuery.java
+++ b/src/main/java/com/kttdevelopment/myanimelist/query/AnimeSearchQuery.java
@@ -1,9 +1,7 @@
 package com.kttdevelopment.myanimelist.query;
 
 import com.kttdevelopment.myanimelist.MyAnimeList;
-import com.kttdevelopment.myanimelist.MyAnimeListService;
 import com.kttdevelopment.myanimelist.anime.Anime;
-import com.kttdevelopment.myanimelist.anime.AnimePreview;
 
 /**
  * <b>Documentation:</b> <a href="https://myanimelist.net/apiconfig/references/api/v2#operation/anime_get">https://myanimelist.net/apiconfig/references/api/v2#operation/anime_get</a> <br>
@@ -23,14 +21,11 @@ public abstract class AnimeSearchQuery extends FieldSearchQuery<AnimeSearchQuery
     /**
      * Creates an Anime search query. Applications do not use this constructor.
      *
-     * @param service MyAnimeList
      *
      * @see MyAnimeList#getAnime()
      * @since 1.0.0
      */
-    public AnimeSearchQuery(final MyAnimeListService service) {
-        super(service);
-    }
+    public AnimeSearchQuery() { }
 
     /**
      * Sets the search query.

--- a/src/main/java/com/kttdevelopment/myanimelist/query/AnimeSeasonQuery.java
+++ b/src/main/java/com/kttdevelopment/myanimelist/query/AnimeSeasonQuery.java
@@ -1,9 +1,7 @@
 package com.kttdevelopment.myanimelist.query;
 
 import com.kttdevelopment.myanimelist.MyAnimeList;
-import com.kttdevelopment.myanimelist.MyAnimeListService;
 import com.kttdevelopment.myanimelist.anime.Anime;
-import com.kttdevelopment.myanimelist.anime.AnimePreview;
 import com.kttdevelopment.myanimelist.anime.property.AnimeSeasonSort;
 import com.kttdevelopment.myanimelist.anime.property.time.Season;
 
@@ -27,7 +25,6 @@ public abstract class AnimeSeasonQuery extends FieldSearchQuery<AnimeSeasonQuery
     /**
      * Creates an Anime season query. Applications do not use this constructor.
      *
-     * @param service MyAnimeList
      * @param year year
      * @param season season
      *
@@ -35,8 +32,7 @@ public abstract class AnimeSeasonQuery extends FieldSearchQuery<AnimeSeasonQuery
      * @see Season
      * @since 1.0.0
      */
-    public AnimeSeasonQuery(final MyAnimeListService service, final int year, final Season season) {
-        super(service);
+    public AnimeSeasonQuery(final int year, final Season season) {
         this.year = year;
         this.season = season;
     }

--- a/src/main/java/com/kttdevelopment/myanimelist/query/AnimeSeasonQuery.java
+++ b/src/main/java/com/kttdevelopment/myanimelist/query/AnimeSeasonQuery.java
@@ -2,6 +2,7 @@ package com.kttdevelopment.myanimelist.query;
 
 import com.kttdevelopment.myanimelist.MyAnimeList;
 import com.kttdevelopment.myanimelist.MyAnimeListService;
+import com.kttdevelopment.myanimelist.anime.Anime;
 import com.kttdevelopment.myanimelist.anime.AnimePreview;
 import com.kttdevelopment.myanimelist.anime.property.AnimeSeasonSort;
 import com.kttdevelopment.myanimelist.anime.property.time.Season;
@@ -16,7 +17,7 @@ import com.kttdevelopment.myanimelist.anime.property.time.Season;
  * @version 1.0.0
  * @author Ktt Development
  */
-public abstract class AnimeSeasonQuery extends FieldSearchQuery<AnimeSeasonQuery,AnimePreview> {
+public abstract class AnimeSeasonQuery extends FieldSearchQuery<AnimeSeasonQuery,Anime> {
 
     protected final int year;
     protected final Season season;

--- a/src/main/java/com/kttdevelopment/myanimelist/query/AnimeSuggestionQuery.java
+++ b/src/main/java/com/kttdevelopment/myanimelist/query/AnimeSuggestionQuery.java
@@ -2,6 +2,7 @@ package com.kttdevelopment.myanimelist.query;
 
 import com.kttdevelopment.myanimelist.MyAnimeList;
 import com.kttdevelopment.myanimelist.MyAnimeListService;
+import com.kttdevelopment.myanimelist.anime.Anime;
 import com.kttdevelopment.myanimelist.anime.AnimePreview;
 
 /**
@@ -14,7 +15,7 @@ import com.kttdevelopment.myanimelist.anime.AnimePreview;
  * @version 1.0.0
  * @author Ktt Development
  */
-public abstract class AnimeSuggestionQuery extends FieldSearchQuery<AnimeSuggestionQuery,AnimePreview> {
+public abstract class AnimeSuggestionQuery extends FieldSearchQuery<AnimeSuggestionQuery,Anime> {
 
     protected String query;
     protected Boolean nsfw;

--- a/src/main/java/com/kttdevelopment/myanimelist/query/AnimeSuggestionQuery.java
+++ b/src/main/java/com/kttdevelopment/myanimelist/query/AnimeSuggestionQuery.java
@@ -1,9 +1,7 @@
 package com.kttdevelopment.myanimelist.query;
 
 import com.kttdevelopment.myanimelist.MyAnimeList;
-import com.kttdevelopment.myanimelist.MyAnimeListService;
 import com.kttdevelopment.myanimelist.anime.Anime;
-import com.kttdevelopment.myanimelist.anime.AnimePreview;
 
 /**
  * <b>Documentation:</b> <a href="https://myanimelist.net/apiconfig/references/api/v2#operation/anime_suggestions_get">https://myanimelist.net/apiconfig/references/api/v2#operation/anime_suggestions_get</a> <br>
@@ -23,14 +21,11 @@ public abstract class AnimeSuggestionQuery extends FieldSearchQuery<AnimeSuggest
     /**
      * Creates an Anime suggestion query. Applications do not use this constructor.
      *
-     * @param service MyAnimeList
      *
      * @see MyAnimeList#getAnimeSuggestions()
      * @since 1.0.0
      */
-    public AnimeSuggestionQuery(final MyAnimeListService service) {
-        super(service);
-    }
+    public AnimeSuggestionQuery() { }
 
     /**
      * Sets the search query.

--- a/src/main/java/com/kttdevelopment/myanimelist/query/FieldSearchQuery.java
+++ b/src/main/java/com/kttdevelopment/myanimelist/query/FieldSearchQuery.java
@@ -1,7 +1,5 @@
 package com.kttdevelopment.myanimelist.query;
 
-import com.kttdevelopment.myanimelist.MyAnimeListService;
-
 import java.util.ArrayList;
 import java.util.List;
 
@@ -20,9 +18,7 @@ abstract class FieldSearchQuery<T extends FieldSearchQuery<T,R>,R> extends Searc
 
     protected List<String> fields;
 
-    FieldSearchQuery(MyAnimeListService service) {
-        super(service);
-    }
+    FieldSearchQuery() { }
 
     /**
      * Adds a field to return.

--- a/src/main/java/com/kttdevelopment/myanimelist/query/ForumSearchQuery.java
+++ b/src/main/java/com/kttdevelopment/myanimelist/query/ForumSearchQuery.java
@@ -1,7 +1,6 @@
 package com.kttdevelopment.myanimelist.query;
 
 import com.kttdevelopment.myanimelist.MyAnimeList;
-import com.kttdevelopment.myanimelist.MyAnimeListService;
 import com.kttdevelopment.myanimelist.forum.ForumTopicDetail;
 import com.kttdevelopment.myanimelist.forum.property.ForumSort;
 
@@ -22,9 +21,7 @@ public abstract class ForumSearchQuery extends FieldSearchQuery<ForumSearchQuery
     protected final String sort = ForumSort.Recent.field();
     protected String topicUsername, username;
     
-    public ForumSearchQuery(final MyAnimeListService service){
-        super(service);
-    }
+    public ForumSearchQuery(){ }
 
     /**
      * Sets the search query.

--- a/src/main/java/com/kttdevelopment/myanimelist/query/ListUpdate.java
+++ b/src/main/java/com/kttdevelopment/myanimelist/query/ListUpdate.java
@@ -1,6 +1,5 @@
 package com.kttdevelopment.myanimelist.query;
 
-import com.kttdevelopment.myanimelist.MyAnimeListService;
 import com.kttdevelopment.myanimelist.property.ListStatus;
 import com.kttdevelopment.myanimelist.query.property.Priority;
 
@@ -21,7 +20,6 @@ import java.util.List;
 @SuppressWarnings("unchecked")
 abstract class ListUpdate<T extends ListUpdate<T,R,S>,R extends ListStatus<?>,S extends Enum<?>> {
 
-    protected final MyAnimeListService service;
     protected final long id;
 
     protected S status;
@@ -30,8 +28,7 @@ abstract class ListUpdate<T extends ListUpdate<T,R,S>,R extends ListStatus<?>,S 
     protected List<String> tags;
     protected String comments;
 
-    ListUpdate(final MyAnimeListService service, final long id){
-        this.service = service;
+    ListUpdate(final long id){
         this.id = id;
     }
 

--- a/src/main/java/com/kttdevelopment/myanimelist/query/MangaListUpdate.java
+++ b/src/main/java/com/kttdevelopment/myanimelist/query/MangaListUpdate.java
@@ -1,6 +1,5 @@
 package com.kttdevelopment.myanimelist.query;
 
-import com.kttdevelopment.myanimelist.MyAnimeListService;
 import com.kttdevelopment.myanimelist.manga.MangaListStatus;
 import com.kttdevelopment.myanimelist.manga.property.MangaStatus;
 import com.kttdevelopment.myanimelist.query.property.RereadValue;
@@ -24,14 +23,13 @@ public abstract class MangaListUpdate extends ListUpdate<MangaListUpdate,MangaLi
     /**
      * Creates a Manga list update. Applications do not use this constructor.
      *
-     * @param service MyAnimeList
      * @param id Manga id
      *
      * @see com.kttdevelopment.myanimelist.MyAnimeList#updateMangaListing(long)
      * @since 1.0.0
      */
-    public MangaListUpdate(final MyAnimeListService service, final long id){
-        super(service, id);
+    public MangaListUpdate(final long id){
+        super( id);
     }
 
     /**

--- a/src/main/java/com/kttdevelopment/myanimelist/query/MangaRankingQuery.java
+++ b/src/main/java/com/kttdevelopment/myanimelist/query/MangaRankingQuery.java
@@ -1,6 +1,5 @@
 package com.kttdevelopment.myanimelist.query;
 
-import com.kttdevelopment.myanimelist.MyAnimeListService;
 import com.kttdevelopment.myanimelist.manga.MangaRanking;
 import com.kttdevelopment.myanimelist.manga.property.MangaRankingType;
 
@@ -22,15 +21,13 @@ public abstract class MangaRankingQuery extends FieldSearchQuery<MangaRankingQue
     /**
      * Creates a Manga ranking query. Applications do not use this constructor.
      *
-     * @param service MyAnimeList
      * @param rankingType ranking type
      *
      * @see com.kttdevelopment.myanimelist.MyAnimeList#getMangaRanking(MangaRankingType)
      * @see MangaRankingType
      * @since 1.0.0
      */
-    public MangaRankingQuery(final MyAnimeListService service, final MangaRankingType rankingType) {
-        super(service);
+    public MangaRankingQuery(final MangaRankingType rankingType) {
         this.rankingType = rankingType;
     }
 

--- a/src/main/java/com/kttdevelopment/myanimelist/query/MangaSearchQuery.java
+++ b/src/main/java/com/kttdevelopment/myanimelist/query/MangaSearchQuery.java
@@ -2,6 +2,7 @@ package com.kttdevelopment.myanimelist.query;
 
 import com.kttdevelopment.myanimelist.MyAnimeList;
 import com.kttdevelopment.myanimelist.MyAnimeListService;
+import com.kttdevelopment.myanimelist.manga.Manga;
 import com.kttdevelopment.myanimelist.manga.MangaPreview;
 
 /**
@@ -14,7 +15,7 @@ import com.kttdevelopment.myanimelist.manga.MangaPreview;
  * @version 1.0.0
  * @author Ktt Development
  */
-public abstract class MangaSearchQuery extends FieldSearchQuery<MangaSearchQuery,MangaPreview> {
+public abstract class MangaSearchQuery extends FieldSearchQuery<MangaSearchQuery,Manga> {
 
     protected String query;
     protected Boolean nsfw;

--- a/src/main/java/com/kttdevelopment/myanimelist/query/MangaSearchQuery.java
+++ b/src/main/java/com/kttdevelopment/myanimelist/query/MangaSearchQuery.java
@@ -1,9 +1,7 @@
 package com.kttdevelopment.myanimelist.query;
 
 import com.kttdevelopment.myanimelist.MyAnimeList;
-import com.kttdevelopment.myanimelist.MyAnimeListService;
 import com.kttdevelopment.myanimelist.manga.Manga;
-import com.kttdevelopment.myanimelist.manga.MangaPreview;
 
 /**
  * <b>Documentation:</b> <a href="https://myanimelist.net/apiconfig/references/api/v2#operation/manga_get">https://myanimelist.net/apiconfig/references/api/v2#operation/manga_get</a> <br>
@@ -23,13 +21,11 @@ public abstract class MangaSearchQuery extends FieldSearchQuery<MangaSearchQuery
     /**
      * Creates a Manga search query. Applications do not use this constructor.
      *
-     * @param service MyAnimeList
      *
      * @see MyAnimeList#getManga()
      * @since 1.0.0
      */
-    public MangaSearchQuery(final MyAnimeListService service) {
-        super(service);
+    public MangaSearchQuery() {
     }
 
     /**

--- a/src/main/java/com/kttdevelopment/myanimelist/query/SearchQuery.java
+++ b/src/main/java/com/kttdevelopment/myanimelist/query/SearchQuery.java
@@ -14,14 +14,10 @@ import java.util.List;
 @SuppressWarnings({"unchecked"})
 abstract class SearchQuery<T extends SearchQuery<T,R>,R> {
 
-    protected final MyAnimeListService service;
-
     protected Integer limit;
     protected Integer offset;
 
-    SearchQuery(final MyAnimeListService service) {
-        this.service = service;
-    }
+    SearchQuery() { }
 
     /**
      * Sets maximum amount of listings to return.

--- a/src/main/java/com/kttdevelopment/myanimelist/query/UserAnimeListQuery.java
+++ b/src/main/java/com/kttdevelopment/myanimelist/query/UserAnimeListQuery.java
@@ -1,7 +1,6 @@
 package com.kttdevelopment.myanimelist.query;
 
 import com.kttdevelopment.myanimelist.MyAnimeList;
-import com.kttdevelopment.myanimelist.MyAnimeListService;
 import com.kttdevelopment.myanimelist.anime.AnimeListStatus;
 import com.kttdevelopment.myanimelist.anime.property.*;
 
@@ -26,15 +25,13 @@ public abstract class UserAnimeListQuery extends FieldSearchQuery<UserAnimeListQ
     /**
      * Creates a user Anime search query. Applications do not use this constructor.
      *
-     * @param service MyAnimeList
      * @param username username
      *
      * @see MyAnimeList#getUserAnimeListing()
      * @see MyAnimeList#getUserAnimeListing(String)
      * @since 1.0.0
      */
-    public UserAnimeListQuery(final MyAnimeListService service, final String username) {
-        super(service);
+    public UserAnimeListQuery(final String username) {
         this.username = username;
     }
 

--- a/src/main/java/com/kttdevelopment/myanimelist/query/UserMangaListQuery.java
+++ b/src/main/java/com/kttdevelopment/myanimelist/query/UserMangaListQuery.java
@@ -1,7 +1,6 @@
 package com.kttdevelopment.myanimelist.query;
 
 import com.kttdevelopment.myanimelist.MyAnimeList;
-import com.kttdevelopment.myanimelist.MyAnimeListService;
 import com.kttdevelopment.myanimelist.manga.MangaListStatus;
 import com.kttdevelopment.myanimelist.manga.property.MangaSort;
 import com.kttdevelopment.myanimelist.manga.property.MangaStatus;
@@ -27,15 +26,13 @@ public abstract class UserMangaListQuery extends FieldSearchQuery<UserMangaListQ
     /**
      * Creates a user Manga search query. Applications do not use this constructor.
      *
-     * @param service MyAnimeList
      * @param username username
      *
      * @see MyAnimeList#getUserMangaListing()
      * @see MyAnimeList#getUserMangaListing(String)
      * @since 1.0.0
      */
-    public UserMangaListQuery(final MyAnimeListService service, final String username) {
-        super(service);
+    public UserMangaListQuery(final String username) {
         this.username = username;
     }
 

--- a/src/test/java/com/kttdevelopment/myanimelist/AnimeTests/TestAnimeSearch.java
+++ b/src/test/java/com/kttdevelopment/myanimelist/AnimeTests/TestAnimeSearch.java
@@ -1,6 +1,7 @@
 package com.kttdevelopment.myanimelist.AnimeTests;
 
 import com.kttdevelopment.myanimelist.*;
+import com.kttdevelopment.myanimelist.anime.Anime;
 import com.kttdevelopment.myanimelist.anime.AnimePreview;
 import org.junit.jupiter.api.*;
 
@@ -17,7 +18,7 @@ public class TestAnimeSearch {
 
     @Test
     public void testSearch(){
-        final List<AnimePreview> search =
+        final List<Anime> search =
             mal.getAnime()
                 .withQuery(TestProvider.AnimeQuery)
                 .search();
@@ -27,7 +28,7 @@ public class TestAnimeSearch {
 
     @Test
     public void testOffsetLimit(){
-        final List<AnimePreview> search =
+        final List<Anime> search =
             mal.getAnime()
                 .withQuery(TestProvider.AnimeQuery)
                 .withLimit(1)
@@ -39,7 +40,7 @@ public class TestAnimeSearch {
 
     @Test
     public void testFields(){
-        final List<AnimePreview> search =
+        final List<Anime> search =
             mal.getAnime()
                 .withQuery(TestProvider.AnimeQuery)
                 .withLimit(1)
@@ -51,7 +52,7 @@ public class TestAnimeSearch {
     @Test
     public void testNSFW(){
         {
-            final List<AnimePreview> search =
+            final List<Anime> search =
                 mal.getAnime()
                     .withQuery(TestProvider.NSFW_AnimeQuery)
                     .withLimit(1)
@@ -59,7 +60,7 @@ public class TestAnimeSearch {
             Assertions.assertEquals(0, search.size());
         }
         {
-            final List<AnimePreview> search =
+            final List<Anime> search =
                 mal.getAnime()
                    .withQuery(TestProvider.NSFW_AnimeQuery)
                    .withLimit(1)

--- a/src/test/java/com/kttdevelopment/myanimelist/AnimeTests/TestAnimeSeason.java
+++ b/src/test/java/com/kttdevelopment/myanimelist/AnimeTests/TestAnimeSeason.java
@@ -2,6 +2,7 @@ package com.kttdevelopment.myanimelist.AnimeTests;
 
 import com.kttdevelopment.myanimelist.MyAnimeList;
 import com.kttdevelopment.myanimelist.TestProvider;
+import com.kttdevelopment.myanimelist.anime.Anime;
 import com.kttdevelopment.myanimelist.anime.AnimePreview;
 import com.kttdevelopment.myanimelist.anime.property.AnimeSeasonSort;
 import com.kttdevelopment.myanimelist.anime.property.time.Season;
@@ -21,10 +22,10 @@ public class TestAnimeSeason {
 
     @Test
     public void testSeason(){
-        final List<AnimePreview> season =
-                mal.getAnimeSeason(2020, Season.Spring)
-                    .withLimit(1)
-                    .search();
+        final List<Anime> season =
+            mal.getAnimeSeason(2020, Season.Spring)
+                .withLimit(1)
+                .search();
         final AnimePreview anime = season.get(0);
         Assertions.assertEquals(2020, anime.getStartSeason().getYear());
         Assertions.assertEquals(Season.Spring, anime.getStartSeason().getSeason());
@@ -32,7 +33,7 @@ public class TestAnimeSeason {
 
     @Test
     public void testSort(){
-        final List<AnimePreview> season =
+        final List<Anime> season =
             mal.getAnimeSeason(2020, Season.Winter)
                 .withLimit(2)
                 .sortBy(AnimeSeasonSort.Score)
@@ -44,11 +45,11 @@ public class TestAnimeSeason {
 
     @Test @DisplayName("#5 - Seasonal") @Disabled
     public void testNSFW(){
-        final List<AnimePreview> season =
+        final List<Anime> season =
             mal.getAnimeSeason(2014, Season.Winter)
                 .search();
         boolean hasNSFW = false;
-        for(final AnimePreview animePreview : season)
+        for(final Anime animePreview : season)
             if(animePreview.getNSFW() != NSFW.White)
                 hasNSFW = true;
         Assertions.assertTrue(hasNSFW);

--- a/src/test/java/com/kttdevelopment/myanimelist/AnimeTests/TestAnimeSuggestions.java
+++ b/src/test/java/com/kttdevelopment/myanimelist/AnimeTests/TestAnimeSuggestions.java
@@ -2,6 +2,7 @@ package com.kttdevelopment.myanimelist.AnimeTests;
 
 import com.kttdevelopment.myanimelist.MyAnimeList;
 import com.kttdevelopment.myanimelist.TestProvider;
+import com.kttdevelopment.myanimelist.anime.Anime;
 import com.kttdevelopment.myanimelist.anime.AnimePreview;
 import org.junit.jupiter.api.*;
 
@@ -18,7 +19,7 @@ public class TestAnimeSuggestions {
 
     @Test
     public void testAnimeSuggestions(){
-        final List<AnimePreview> suggestions =
+        final List<Anime> suggestions =
             mal.getAnimeSuggestions()
                 .search();
         Assertions.assertNotNull(suggestions);

--- a/src/test/java/com/kttdevelopment/myanimelist/MangaTests/TestMangaSearch.java
+++ b/src/test/java/com/kttdevelopment/myanimelist/MangaTests/TestMangaSearch.java
@@ -3,6 +3,7 @@ package com.kttdevelopment.myanimelist.MangaTests;
 import com.kttdevelopment.myanimelist.MyAnimeList;
 import com.kttdevelopment.myanimelist.TestProvider;
 import com.kttdevelopment.myanimelist.anime.AnimePreview;
+import com.kttdevelopment.myanimelist.manga.Manga;
 import com.kttdevelopment.myanimelist.manga.MangaPreview;
 import org.junit.jupiter.api.*;
 
@@ -19,7 +20,7 @@ public class TestMangaSearch {
 
     @Test
     public void testSearch(){
-        final List<MangaPreview> search =
+        final List<Manga> search =
             mal.getManga()
                 .withQuery(TestProvider.AltMangaQuery)
                 .search();
@@ -29,7 +30,7 @@ public class TestMangaSearch {
 
     @Test
     public void testOffsetLimit(){
-        final List<MangaPreview> search =
+        final List<Manga> search =
             mal.getManga()
                 .withQuery(TestProvider.AltMangaQuery)
                 .withLimit(1)
@@ -41,8 +42,8 @@ public class TestMangaSearch {
 
     @Test
     public void testFields(){
-        final List<AnimePreview> search =
-            mal.getAnime()
+        final List<Manga> search =
+            mal.getManga()
                 .withQuery(TestProvider.MangaQuery)
                 .withLimit(1)
                 .withFields(new String[0])
@@ -53,7 +54,7 @@ public class TestMangaSearch {
     @Test
     public void testNSFW(){
         {
-            final List<MangaPreview> search =
+            final List<Manga> search =
                 mal.getManga()
                     .withQuery(TestProvider.NSFW_MangaQuery)
                     .withLimit(1)
@@ -61,7 +62,7 @@ public class TestMangaSearch {
             Assertions.assertEquals(0, search.size());
         }
         {
-            final List<MangaPreview> search =
+            final List<Manga> search =
                 mal.getManga()
                    .withQuery(TestProvider.NSFW_MangaQuery)
                    .withLimit(1)

--- a/src/test/java/com/kttdevelopment/myanimelist/TestIterator.java
+++ b/src/test/java/com/kttdevelopment/myanimelist/TestIterator.java
@@ -1,6 +1,6 @@
 package com.kttdevelopment.myanimelist;
 
-import com.kttdevelopment.myanimelist.anime.AnimePreview;
+import com.kttdevelopment.myanimelist.anime.Anime;
 import org.junit.jupiter.api.*;
 
 public class TestIterator {
@@ -14,14 +14,14 @@ public class TestIterator {
 
     @Test
     public void testIterator(){
-        final PaginatedIterator<AnimePreview> iterator = mal
+        final PaginatedIterator<Anime> iterator = mal
             .getAnime()
             .withQuery(TestProvider.AnimeQuery)
             .withLimit(100)
             .withFields("id")
             .searchAll();
 
-        final AnimePreview first = iterator.next();
+        final Anime first = iterator.next();
         Assertions.assertEquals(TestProvider.AnimeID, first.getID());
         iterator.forEachRemaining(animePreview -> Assertions.assertNotEquals(TestProvider.AnimeID, animePreview.getID()));
     }

--- a/src/test/java/com/kttdevelopment/myanimelist/TestIterator.java
+++ b/src/test/java/com/kttdevelopment/myanimelist/TestIterator.java
@@ -17,7 +17,6 @@ public class TestIterator {
         final PaginatedIterator<Anime> iterator = mal
             .getAnime()
             .withQuery(TestProvider.AnimeQuery)
-            .withLimit(100)
             .withFields("id")
             .searchAll();
 

--- a/src/test/java/com/kttdevelopment/myanimelist/TestIterator.java
+++ b/src/test/java/com/kttdevelopment/myanimelist/TestIterator.java
@@ -18,6 +18,7 @@ public class TestIterator {
             .getAnime()
             .withQuery(TestProvider.AnimeQuery)
             .withFields("id")
+            .withLimit(100)
             .searchAll();
 
         final Anime first = iterator.next();

--- a/src/test/java/com/kttdevelopment/myanimelist/TestJson.java
+++ b/src/test/java/com/kttdevelopment/myanimelist/TestJson.java
@@ -106,8 +106,8 @@ public class TestJson {
         Assertions.assertTrue(json.contains("string"));
         Assertions.assertTrue(json.contains("str\"ingx"));
         Assertions.assertTrue(json.contains("/\\"));
-        Assertions.assertEquals("v", ((JsonObject) json.get(11)).getString("k"));
-        Assertions.assertEquals(0, ((JsonObject) json.get(12)).size());
+        Assertions.assertEquals("v", ((JsonObject) json.get(12)).getString("k"));
+        Assertions.assertEquals(0, ((JsonObject) json.get(13)).size());
         Assertions.assertTrue(json.contains(List.of("str")));
         Assertions.assertTrue(json.contains(List.of()));
     }

--- a/src/test/java/com/kttdevelopment/myanimelist/TestJson.java
+++ b/src/test/java/com/kttdevelopment/myanimelist/TestJson.java
@@ -27,6 +27,7 @@ public class TestJson {
                 "\"string\": \"string\",",
                 "\"strings\":\"string\",",
                 "\"str\\\"ingx\":\"str\\\"ing\",",
+                "\"slash\": \"\\/\\\\\",",
                 "\"obj\": {" +
                     "\"k\": \"v\"" +
                 "}," +
@@ -55,6 +56,7 @@ public class TestJson {
         Assertions.assertEquals("string", json.getString("string"));
         Assertions.assertEquals("string", json.getString("strings"));
         Assertions.assertEquals("str\"ing", json.getString("str\"ingx"));
+        Assertions.assertEquals("/\\", json.getString("slash"));
         Assertions.assertEquals("v", json.getJsonObject("obj").getString("k"));
         Assertions.assertEquals(0, json.getJsonObject("cobj").size());
         Assertions.assertEquals("str", json.getStringArray("arr")[0]);
@@ -76,6 +78,7 @@ public class TestJson {
                 "null,",
                 "\"string\",",
                 " \"str\\\"ingx\",",
+                "\"\\/\\\\\",",
                 "{" +
                     "\"k\": \"v\"" +
                 "}," +
@@ -86,6 +89,8 @@ public class TestJson {
                 "[]" +
             "]"
         );
+
+        // \/\\
 
         final List<?> json = (List<?>) parse(arr);
 
@@ -100,6 +105,7 @@ public class TestJson {
         Assertions.assertTrue(json.contains(null));
         Assertions.assertTrue(json.contains("string"));
         Assertions.assertTrue(json.contains("str\"ingx"));
+        Assertions.assertTrue(json.contains("/\\"));
         Assertions.assertEquals("v", ((JsonObject) json.get(11)).getString("k"));
         Assertions.assertEquals(0, ((JsonObject) json.get(12)).size());
         Assertions.assertTrue(json.contains(List.of("str")));


### PR DESCRIPTION
- Fixed issue where queries would return a preview instead of the full object.
- Fixed #28 pagination now only uses 1 call.
- Fixed issue where certain search queries were still using unoptimized 3 request search.
- Fixed critical issue where pagination would not work unless limit was supplied (now uses 100 default as stipulated by the API).
- Fixed #32 