### PR TITLE
Have no fields return default fields

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -11,6 +11,8 @@ assignees: ''
 *If **all** checks are not passed then the issue will be closed.*
 - [ ] I have checked that no other similar issue already exists.
 - [ ] I have checked that this issue is actually a bug and not a feature.
+- [ ] I have checked the [documentation](https://myanimelist.kttdevelopment.com/documentation/)
+- [ ] I have checked the [FAQ](https://myanimelist.kttdevelopment.com/faq/)
 - [ ] I am running the latest release version.
 
 **Operating System:** *Operating system name and version.*

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,11 +1,17 @@
 blank_issues_enabled: false
 contact_links:
-  - name: Feature Requests
-    url: https://github.com/Katsute/MyAnimeList-Java-API/discussions/categories/feature-requests
-    about: New feature requests must be posted here first before they may become an issue
+  - name: FAQ
+    about: Check frequently asked questions before posting an issue
+    url: https://myanimelist.kttdevelopment.com/faq/
   - name: Discussions
     url: https://github.com/Katsute/MyAnimeList-Java-API/discussions
     about: Check here before posting an issue
+  - name: Feature Requests
+    url: https://github.com/Katsute/MyAnimeList-Java-API/discussions/categories/feature-requests
+    about: New feature requests must be posted here first before they may become an issue
+  - name: MyAnimeList API
+    url: https://myanimelist.net/apiconfig/references/api/v2
+    about: The official MyAnimeList API documentation
   - name: Official MyAnimeList API Club
     url: https://myanimelist.net/clubs.php?cid=13727
     about: We do not maintain the MyAnimeList API, issues regarding the API itself should be posted in their official club

--- a/.github/ISSUE_TEMPLATE/error_report.md
+++ b/.github/ISSUE_TEMPLATE/error_report.md
@@ -11,6 +11,8 @@ assignees: ''
 *If **all** checks are not passed then the issue will be closed.*
 - [ ] I have checked that no other similar issue already exists.
 - [ ] I have checked that this issue is actually a bug and not a feature.
+- [ ] I have checked the [documentation](https://myanimelist.kttdevelopment.com/documentation/)
+- [ ] I have checked the [FAQ](https://myanimelist.kttdevelopment.com/faq/)
 - [ ] I am running the latest release version.
 
 **Operating System:** *Operating system name and version.*

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@
         •
         <a href="https://myanimelist.kttdevelopment.com/setup/">Setup</a>
         •
+        <a href="https://myanimelist.kttdevelopment.com/faq/">FAQ</a>
+        •
         <a href="https://github.com/Katsute/MyAnimeList-Java-API/issues">Issues</a>
         •
         <a href="https://github.com/Katsute/MyAnimeList-Java-API/discussions">Discussions</a>

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
         <br />
         <a href="https://myanimelist.kttdevelopment.com/documentation/">Docs</a>
         •
+        <a href="https://myanimelist.net/apiconfig/references/api/v2">API Docs</a>
+        •
         <a href="https://myanimelist.kttdevelopment.com/setup/">Setup</a>
         •
         <a href="https://myanimelist.kttdevelopment.com/faq/">FAQ</a>

--- a/docs/_data/nav.yml
+++ b/docs/_data/nav.yml
@@ -4,6 +4,8 @@
   link: /documentation
 - name: Setup
   link: /setup
+- name: FAQ
+  link: /FAQ
 - name: Discussion
   link: https://github.com/Katsute/MyAnimeList-Java-API/discussions
   new: true

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,0 +1,31 @@
+---
+heading: |
+    <h1 class="display-3">FAQ</h1>
+    <p class="mt-3 mb-5">
+        Frequently asked questions.
+    </p>
+---
+# General
+
+## Are their any rate limits?
+
+The MyAnimeList API currently has no rate limit in place so requests must be sent at your own discretion. Note that this Java library is currently operating at maximum efficiency, using only one request per method.
+
+## What does this library offer in comparison to the Official API?
+
+This library offers ***ALL*** the features provided by the API.
+
+## My auth token doesn't work.
+
+- Make sure that you are providing an auth token and not the client id.
+- Your token may be expired.
+
+# Methods
+
+## All the fields are null.
+
+By default this library follows the API and returns only the fields provided in the fields parameter. If you want all the fields use `MyAnimeList#ALL_ANIME_FIELDS`, `MyAnimeList#ALL_MANGA_FIELDS`, or `MyAnimeList#ALL_USER_FIELDS`.
+
+## NSFW is not working.
+
+For search queries make sure you also run `#includeNSFW()` in the query builder.

--- a/docs/features.md
+++ b/docs/features.md
@@ -10,6 +10,7 @@ List<AnimePreview> search =
         .withQuery("さくら荘のペットな彼女")
         .withLimit(1)
         .withOffset(1)
+        .withFields(MyAnimeList.ALL_ANIME_FIELDS)
         .includeNSFW(false)
         .search();
 ```
@@ -39,7 +40,7 @@ MangaListStatus status =
 <hr>
 ```java
 MyAnimeList mal = MyAnimeList.withOAuthToken("");
-Anime anime = mal.getAnime(13759);
+Anime anime = mal.getAnime(13759, MyAnimeList.ALL_ANIME_FIELDS);
 
 String ja = anime.getAlternativeTitles().getJapanese();
 Genre[] genres = anime.getGenres();

--- a/src/main/java/com/kttdevelopment/myanimelist/MyAnimeList.java
+++ b/src/main/java/com/kttdevelopment/myanimelist/MyAnimeList.java
@@ -25,7 +25,23 @@ public abstract class MyAnimeList {
     /**
      * Indicates that only default fields should be returned.
      */
-    public static String[] NO_FIELDS = new String[0];
+    public static final String[] NO_FIELDS = new String[0];
+
+    /**
+     * Returns all possible Anime fields.
+     */
+    @SuppressWarnings("SpellCheckingInspection")
+    public static final String ALL_ANIME_FIELDS = "id,title,main_picture,alternative_titles,start_date,end_date,synopsis,mean,rank,popularity,num_list_users,num_scoring_users,nsfw,created_at,updated_at,media_type,status,genres,num_episodes,start_season,broadcast,source,average_episode_duration,rating,pictures,background,related_anime,related_manga,recommendations,studios,statistics,my_list_status{start_date,end_date,priority,num_times_rewatched,rewatch_value,tags,comments},list_status{start_date,end_date,priority,num_times_rewatched,rewatch_value,tags,comments}";
+
+    /**
+     * Returns all possible Manga fields.
+     */
+    public static final String ALL_MANGA_FIELDS = "id,title,main_picture,alternative_titles,start_date,end_date,synopsis,mean,rank,popularity,num_list_users,num_scoring_users,nsfw,created_at,updated_at,media_type,status,genres,num_volumes,num_chapters,authors{first_name,last_name},pictures,background,related_anime,related_manga,recommendations,serialization{name,role},my_list_status{start_date,finish_date,priority,num_times_reread,reread_value,tags,comments},list_status{start_date,finish_date,priority,num_times_reread,reread_value,tags,comments}";
+
+    /**
+     * Returns all possible User fields.
+     */
+    public static final String ALL_USER_FIELDS = "birthday,time_zone,anime_statistics";
 
     /**
      * Creates an interface with an OAuth token. Note that this method does not support {@link #refreshOAuthToken()}.
@@ -436,7 +452,7 @@ public abstract class MyAnimeList {
      * @see #getMyself()
      * @since 1.0.0
      */
-    public abstract User getMyself(final String[] fields);
+    public abstract User getMyself(final String... fields);
 
     /**
      * Returns a user given their username.

--- a/src/main/java/com/kttdevelopment/myanimelist/MyAnimeList.java
+++ b/src/main/java/com/kttdevelopment/myanimelist/MyAnimeList.java
@@ -120,6 +120,7 @@ public abstract class MyAnimeList {
      *
      * @see Anime
      * @see #getAnime()
+     * @see #ALL_ANIME_FIELDS
      * @since 1.0.0
      */
     public abstract Anime getAnime(final long id, final String... fields);
@@ -345,6 +346,7 @@ public abstract class MyAnimeList {
      *
      * @see Manga
      * @see #getManga()
+     * @see #ALL_MANGA_FIELDS
      * @since 1.0.0
      */
     public abstract Manga getManga(final long id, final String... fields);
@@ -450,6 +452,7 @@ public abstract class MyAnimeList {
      *
      * @see User
      * @see #getMyself()
+     * @see #ALL_USER_FIELDS
      * @since 1.0.0
      */
     public abstract User getMyself(final String... fields);
@@ -479,6 +482,7 @@ public abstract class MyAnimeList {
      *
      * @see User
      * @see #getUser(String)
+     * @see #ALL_USER_FIELDS
      * @since 1.0.0
      */
     public abstract User getUser(final String username, final String... fields);

--- a/src/main/java/com/kttdevelopment/myanimelist/MyAnimeList.java
+++ b/src/main/java/com/kttdevelopment/myanimelist/MyAnimeList.java
@@ -115,7 +115,7 @@ public abstract class MyAnimeList {
      * @throws HTTPException if request failed
      * @throws UncheckedIOException if client failed to execute request
      * @param id Anime id
-     * @param fields the fields that should be returned
+     * @param fields a comma separated string or a string array of the fields that should be returned
      * @return Anime
      *
      * @see Anime
@@ -340,7 +340,7 @@ public abstract class MyAnimeList {
      * @throws HTTPException if request failed
      * @throws UncheckedIOException if client failed to execute request
      * @param id Manga id
-     * @param fields the fields that should be returned
+     * @param fields a comma separated string or a string array of the fields that should be returned
      * @return Manga
      *
      * @see Manga
@@ -443,7 +443,7 @@ public abstract class MyAnimeList {
     /**
      * Returns the authenticated user.
      *
-     * @param fields the fields to return
+     * @param fields a comma separated string or a string array of the fields that should be returned
      * @return user
      * @throws HTTPException if request failed
      * @throws UncheckedIOException if client failed to execute request
@@ -472,7 +472,7 @@ public abstract class MyAnimeList {
      * Returns a user given their username.
      *
      * @param username username
-     * @param fields the fields to return
+     * @param fields a comma separated string or a string array of the fields that should be returned
      * @return user
      * @throws HTTPException if request failed
      * @throws UncheckedIOException if client failed to execute request

--- a/src/main/java/com/kttdevelopment/myanimelist/MyAnimeListImpl.java
+++ b/src/main/java/com/kttdevelopment/myanimelist/MyAnimeListImpl.java
@@ -61,9 +61,6 @@ final class MyAnimeListImpl extends MyAnimeList{
 
     //
 
-    @SuppressWarnings("SpellCheckingInspection")
-    private static final String animeFields = "id,title,main_picture,alternative_titles,start_date,end_date,synopsis,mean,rank,popularity,num_list_users,num_scoring_users,nsfw,created_at,updated_at,media_type,status,genres,num_episodes,start_season,broadcast,source,average_episode_duration,rating,pictures,background,related_anime,related_manga,recommendations,studios,statistics,my_list_status{start_date,end_date,priority,num_times_rewatched,rewatch_value,tags,comments},list_status{start_date,end_date,priority,num_times_rewatched,rewatch_value,tags,comments}";
-
     @Override
     public final AnimeSearchQuery getAnime(){
         return new AnimeSearchQuery() {
@@ -76,7 +73,7 @@ final class MyAnimeListImpl extends MyAnimeList{
                         query,
                         between(0, limit, 100),
                         between(0, offset, null),
-                        fields == null ? animeFields : asStringList(fields),
+                        asStringList(fields),
                         nsfw)
                 );
                 if(response == null) return null;
@@ -96,7 +93,7 @@ final class MyAnimeListImpl extends MyAnimeList{
                         query,
                         between(0, limit, 100),
                         offset,
-                        fields == null ? animeFields : asStringList(fields),
+                        asStringList(fields),
                         nsfw),
                     iterator -> asAnime(MyAnimeListImpl.this, iterator.getJsonObject("node"))
                 );
@@ -116,7 +113,7 @@ final class MyAnimeListImpl extends MyAnimeList{
             () -> service.getAnime(
                 auth,
                 id,
-                fields == null ? animeFields : asStringList(fields))
+                asStringList(fields))
         ));
     }
 
@@ -132,7 +129,7 @@ final class MyAnimeListImpl extends MyAnimeList{
                         rankingType.field(),
                         between(0, limit, 500),
                         between(0, offset, null),
-                        fields == null ? animeFields : asStringList(fields),
+                        asStringList(fields),
                         nsfw)
                 );
                 if(response == null) return null;
@@ -152,7 +149,7 @@ final class MyAnimeListImpl extends MyAnimeList{
                         rankingType.field(),
                         between(0, limit, 500),
                         offset,
-                        fields == null ? animeFields : asStringList(fields),
+                        asStringList(fields),
                         nsfw),
                     iterator -> asAnimeRanking(MyAnimeListImpl.this, iterator)
                 );
@@ -174,7 +171,7 @@ final class MyAnimeListImpl extends MyAnimeList{
                         sort != null ? sort.field() : null,
                         between(0, limit, 500),
                         between(0, offset, null),
-                        fields == null ? animeFields : asStringList(fields),
+                        asStringList(fields),
                         nsfw)
                 );
                 if(response == null) return null;
@@ -196,7 +193,7 @@ final class MyAnimeListImpl extends MyAnimeList{
                         sort != null ? sort.field() : null,
                         between(0, limit, 500),
                         offset,
-                        fields == null ? animeFields : asStringList(fields),
+                        asStringList(fields),
                         nsfw),
                     iterator -> asAnime(MyAnimeListImpl.this, iterator.getJsonObject("node"))
                 );
@@ -216,7 +213,7 @@ final class MyAnimeListImpl extends MyAnimeList{
                         auth,
                         between(0, limit, 100),
                         between(0, offset, null),
-                        fields == null ? animeFields : asStringList(fields),
+                        asStringList(fields),
                         nsfw)
                 );
                 if(response == null) return null;
@@ -235,7 +232,7 @@ final class MyAnimeListImpl extends MyAnimeList{
                         auth,
                         between(0, limit, 100),
                         offset,
-                        fields == null ? animeFields : asStringList(fields),
+                        asStringList(fields),
                         nsfw),
                     iterator -> asAnime(MyAnimeListImpl.this, iterator.getJsonObject("node"))
                 );
@@ -300,7 +297,7 @@ final class MyAnimeListImpl extends MyAnimeList{
                         sort != null ? sort.field() : null,
                         between(0, limit, 1000),
                         between(0, offset, null),
-                        fields == null ? animeFields : asStringList(fields))
+                        asStringList(fields))
                 );
                 if(response == null) return null;
 
@@ -321,7 +318,7 @@ final class MyAnimeListImpl extends MyAnimeList{
                         sort != null ? sort.field() : null,
                         between(0, limit, 1000),
                         offset,
-                        fields == null ? animeFields : asStringList(fields)),
+                        asStringList(fields)),
                     iterator -> asAnimeListStatus(MyAnimeListImpl.this, iterator.getJsonObject("list_status"), asAnimePreview(MyAnimeListImpl.this, iterator.getJsonObject("node")))
                 );
             }
@@ -414,8 +411,6 @@ final class MyAnimeListImpl extends MyAnimeList{
         };
     }
 
-    private static final String mangaFields = "id,title,main_picture,alternative_titles,start_date,end_date,synopsis,mean,rank,popularity,num_list_users,num_scoring_users,nsfw,created_at,updated_at,media_type,status,genres,num_volumes,num_chapters,authors{first_name,last_name},pictures,background,related_anime,related_manga,recommendations,serialization{name,role},my_list_status{start_date,finish_date,priority,num_times_reread,reread_value,tags,comments},list_status{start_date,finish_date,priority,num_times_reread,reread_value,tags,comments}";
-
     @Override
     public final MangaSearchQuery getManga(){
         return new MangaSearchQuery() {
@@ -428,7 +423,7 @@ final class MyAnimeListImpl extends MyAnimeList{
                         query,
                         between(0, limit, 100),
                         between(0, offset, null),
-                        fields == null ? mangaFields : asStringList(fields),
+                        asStringList(fields),
                         nsfw)
                 );
                 if(response == null) return null;
@@ -448,7 +443,7 @@ final class MyAnimeListImpl extends MyAnimeList{
                         query,
                         between(0, limit, 100),
                         offset,
-                        fields == null ? mangaFields : asStringList(fields),
+                        asStringList(fields),
                         nsfw),
                     iterator -> asManga(MyAnimeListImpl.this, iterator.getJsonObject("node"))
                 );
@@ -469,7 +464,7 @@ final class MyAnimeListImpl extends MyAnimeList{
             () -> service.getManga(
                 auth,
                 id,
-                fields == null ? mangaFields : asStringList(fields))
+                asStringList(fields))
         ));
     }
 
@@ -485,7 +480,7 @@ final class MyAnimeListImpl extends MyAnimeList{
                         rankingType != null ? rankingType.field() : null,
                         between(0, limit, 500),
                         between(0, offset, null),
-                        fields == null ? mangaFields : asStringList(fields),
+                        asStringList(fields),
                         nsfw)
                 );
                 if(response == null) return null;
@@ -505,7 +500,7 @@ final class MyAnimeListImpl extends MyAnimeList{
                         rankingType != null ? rankingType.field() : null,
                         between(0, limit, 500),
                         offset,
-                        fields == null ? mangaFields : asStringList(fields),
+                        asStringList(fields),
                         nsfw),
                     iterator -> asMangaRanking(MyAnimeListImpl.this, iterator)
                 );
@@ -571,7 +566,7 @@ final class MyAnimeListImpl extends MyAnimeList{
                         sort != null ? sort.field() : null,
                         between(0, limit, 1000),
                         between(0, offset, null),
-                        fields == null ? mangaFields : asStringList(fields))
+                        asStringList(fields))
                 );
                 if(response == null) return null;
 
@@ -592,15 +587,13 @@ final class MyAnimeListImpl extends MyAnimeList{
                         sort != null ? sort.field() : null,
                         between(0, limit, 1000),
                         offset,
-                        fields == null ? mangaFields : asStringList(fields)),
+                        asStringList(fields)),
                     iterator -> asMangaListStatus(MyAnimeListImpl.this, iterator.getJsonObject("list_status"), asMangaPreview(MyAnimeListImpl.this, iterator.getJsonObject("node")))
                 );
             }
 
         };
     }
-
-    private static final String userFields = "birthday,time_zone,anime_statistics";
 
     @Override
     public final User getMyself(){
@@ -624,7 +617,7 @@ final class MyAnimeListImpl extends MyAnimeList{
             () -> service.getUser(
                 auth,
                 username.equals("@me") ? "@me" : URLEncoder.encode(username, StandardCharsets.UTF_8),
-                fields == null ? userFields : asStringList(fields))
+                asStringList(fields))
         ));
     }
 
@@ -755,7 +748,7 @@ final class MyAnimeListImpl extends MyAnimeList{
             if(!str.isBlank())
                 return str.substring(0, str.length() -1);
         }
-        return fields == null ? null : "";
+        return null;
     }
 
     //

--- a/src/main/java/com/kttdevelopment/myanimelist/query/FieldSearchQuery.java
+++ b/src/main/java/com/kttdevelopment/myanimelist/query/FieldSearchQuery.java
@@ -28,6 +28,8 @@ abstract class FieldSearchQuery<T extends FieldSearchQuery<T,R>,R> extends Searc
      *
      * @see #withFields(String...)
      * @see #withFields(List)
+     * @see com.kttdevelopment.myanimelist.MyAnimeList#ALL_ANIME_FIELDS
+     * @see com.kttdevelopment.myanimelist.MyAnimeList#ALL_MANGA_FIELDS
      * @since 1.0.0
      */
     public final T withField(final String field){
@@ -47,6 +49,8 @@ abstract class FieldSearchQuery<T extends FieldSearchQuery<T,R>,R> extends Searc
      *
      * @see #withField(String)
      * @see #withFields(List)
+     * @see com.kttdevelopment.myanimelist.MyAnimeList#ALL_ANIME_FIELDS
+     * @see com.kttdevelopment.myanimelist.MyAnimeList#ALL_MANGA_FIELDS
      * @since 1.0.0
      */
     public final T withFields(final String... fields){

--- a/src/main/java/com/kttdevelopment/myanimelist/query/FieldSearchQuery.java
+++ b/src/main/java/com/kttdevelopment/myanimelist/query/FieldSearchQuery.java
@@ -31,6 +31,8 @@ abstract class FieldSearchQuery<T extends FieldSearchQuery<T,R>,R> extends Searc
      * @since 1.0.0
      */
     public final T withField(final String field){
+        if(fields == null)
+            this.fields = new ArrayList<>();
         if(!this.fields.contains(field))
             this.fields.add(field);
         return (T) this;

--- a/src/main/java/com/kttdevelopment/myanimelist/query/FieldSearchQuery.java
+++ b/src/main/java/com/kttdevelopment/myanimelist/query/FieldSearchQuery.java
@@ -23,7 +23,7 @@ abstract class FieldSearchQuery<T extends FieldSearchQuery<T,R>,R> extends Searc
     /**
      * Adds a field to return.
      *
-     * @param field field
+     * @param field a field or comma separated fields that should be returned
      * @return query
      *
      * @see #withFields(String...)
@@ -41,7 +41,7 @@ abstract class FieldSearchQuery<T extends FieldSearchQuery<T,R>,R> extends Searc
     /**
      * Adds a list of fields to return.
      *
-     * @param fields fields
+     * @param fields a comma separated string or a string array of the fields that should be returned
      *
      * @return query
      *
@@ -64,7 +64,7 @@ abstract class FieldSearchQuery<T extends FieldSearchQuery<T,R>,R> extends Searc
     /**
      * Adds a list of fields to return.
      *
-     * @param fields fields
+     * @param fields a list of the fields that should be returned
      *
      * @return query
      *

--- a/src/test/java/com/kttdevelopment/myanimelist/AnimeTests/TestAnime.java
+++ b/src/test/java/com/kttdevelopment/myanimelist/AnimeTests/TestAnime.java
@@ -17,7 +17,7 @@ public class TestAnime {
     @BeforeAll
     public static void beforeAll(){
         mal = TestProvider.getMyAnimeList();
-        anime = mal.getAnime(TestProvider.AltAnimeID);
+        anime = mal.getAnime(TestProvider.AltAnimeID, MyAnimeList.ALL_ANIME_FIELDS);
     }
 
     @Test

--- a/src/test/java/com/kttdevelopment/myanimelist/AnimeTests/TestAnimeListStatus.java
+++ b/src/test/java/com/kttdevelopment/myanimelist/AnimeTests/TestAnimeListStatus.java
@@ -79,6 +79,7 @@ public class TestAnimeListStatus {
             mal.getUserAnimeListing()
                 .withStatus(AnimeStatus.Watching)
                 .withLimit(1000)
+                .withField(MyAnimeList.ALL_ANIME_FIELDS)
                 .search();
 
         AnimeListStatus status = null;
@@ -95,7 +96,9 @@ public class TestAnimeListStatus {
 
     @Test @Order(3)
     public void testGetFromAnime(){
-        final AnimeListStatus status = mal.getAnime(TestProvider.AnimeID).getListStatus();
+        final AnimeListStatus status = mal
+            .getAnime(TestProvider.AnimeID, MyAnimeList.ALL_ANIME_FIELDS)
+            .getListStatus();
         testStatus(status);
     }
 

--- a/src/test/java/com/kttdevelopment/myanimelist/AnimeTests/TestAnimeRank.java
+++ b/src/test/java/com/kttdevelopment/myanimelist/AnimeTests/TestAnimeRank.java
@@ -21,9 +21,10 @@ public class TestAnimeRank {
     @Test
     public void testRanking(){
         final List<AnimeRanking> ranking =
-                mal.getAnimeRanking(AnimeRankingType.Movie)
-                    .withLimit(1)
-                    .search();
+            mal.getAnimeRanking(AnimeRankingType.Movie)
+                .withLimit(1)
+                .withField(MyAnimeList.ALL_ANIME_FIELDS)
+                .search();
         final AnimeRanking first = ranking.get(0);
         Assertions.assertEquals(1, first.getRanking());
         Assertions.assertTrue(first.getPreviousRank() < 1);

--- a/src/test/java/com/kttdevelopment/myanimelist/AnimeTests/TestAnimeSearch.java
+++ b/src/test/java/com/kttdevelopment/myanimelist/AnimeTests/TestAnimeSearch.java
@@ -44,7 +44,6 @@ public class TestAnimeSearch {
             mal.getAnime()
                 .withQuery(TestProvider.AnimeQuery)
                 .withLimit(1)
-                .withFields(MyAnimeList.NO_FIELDS)
                 .search();
         Assertions.assertNull(search.get(0).getType());
     }

--- a/src/test/java/com/kttdevelopment/myanimelist/AnimeTests/TestAnimeSeason.java
+++ b/src/test/java/com/kttdevelopment/myanimelist/AnimeTests/TestAnimeSeason.java
@@ -25,6 +25,7 @@ public class TestAnimeSeason {
         final List<Anime> season =
             mal.getAnimeSeason(2020, Season.Spring)
                 .withLimit(1)
+                .withField("start_season")
                 .search();
         final AnimePreview anime = season.get(0);
         Assertions.assertEquals(2020, anime.getStartSeason().getYear());
@@ -37,6 +38,7 @@ public class TestAnimeSeason {
             mal.getAnimeSeason(2020, Season.Winter)
                 .withLimit(2)
                 .sortBy(AnimeSeasonSort.Score)
+                .withField(MyAnimeList.ALL_ANIME_FIELDS)
                 .search();
         final AnimePreview first = season.get(0);
         final AnimePreview second = season.get(1);

--- a/src/test/java/com/kttdevelopment/myanimelist/AnimeTests/TestAnimeSeason.java
+++ b/src/test/java/com/kttdevelopment/myanimelist/AnimeTests/TestAnimeSeason.java
@@ -37,12 +37,12 @@ public class TestAnimeSeason {
         final List<Anime> season =
             mal.getAnimeSeason(2020, Season.Winter)
                 .withLimit(2)
-                .sortBy(AnimeSeasonSort.Score)
+                .sortBy(AnimeSeasonSort.Users)
                 .withField(MyAnimeList.ALL_ANIME_FIELDS)
                 .search();
         final AnimePreview first = season.get(0);
         final AnimePreview second = season.get(1);
-        Assertions.assertTrue(first.getMeanRating() > second.getMeanRating());
+        Assertions.assertTrue(first.getUserScoringCount() > second.getUserScoringCount());
     }
 
     @Test @DisplayName("#5 - Seasonal") @Disabled

--- a/src/test/java/com/kttdevelopment/myanimelist/AnimeTests/TestUserAnimeListing.java
+++ b/src/test/java/com/kttdevelopment/myanimelist/AnimeTests/TestUserAnimeListing.java
@@ -23,6 +23,7 @@ public class TestUserAnimeListing {
         final List<AnimeListStatus> list =
             mal.getUserAnimeListing()
                .withStatus(AnimeStatus.Dropped)
+               .withField(MyAnimeList.ALL_ANIME_FIELDS)
                .search();
         Assertions.assertEquals(AnimeStatus.Dropped, list.get(0).getStatus());
     }
@@ -32,6 +33,7 @@ public class TestUserAnimeListing {
         final List<AnimeListStatus> list =
             mal.getUserAnimeListing()
                .sortBy(AnimeSort.UpdatedAt)
+               .withField(MyAnimeList.ALL_ANIME_FIELDS)
                .search();
         Assertions.assertTrue(list.get(0).getUpdatedAt() > list.get(1).getUpdatedAt());
     }

--- a/src/test/java/com/kttdevelopment/myanimelist/MangaTests/TestManga.java
+++ b/src/test/java/com/kttdevelopment/myanimelist/MangaTests/TestManga.java
@@ -16,7 +16,7 @@ public class TestManga {
     @BeforeAll
     public static void beforeAll(){
         mal = TestProvider.getMyAnimeList();
-        manga = mal.getManga(TestProvider.MangaID);
+        manga = mal.getManga(TestProvider.MangaID, MyAnimeList.ALL_MANGA_FIELDS);
     }
 
     @Test

--- a/src/test/java/com/kttdevelopment/myanimelist/MangaTests/TestMangaListStatus.java
+++ b/src/test/java/com/kttdevelopment/myanimelist/MangaTests/TestMangaListStatus.java
@@ -81,6 +81,7 @@ public class TestMangaListStatus {
             mal.getUserMangaListing()
                 .withStatus(MangaStatus.Reading)
                 .withLimit(1000)
+                .withField(MyAnimeList.ALL_MANGA_FIELDS)
                 .search();
 
         MangaListStatus status = null;
@@ -97,7 +98,7 @@ public class TestMangaListStatus {
 
     @Test @Order(3)
     public void testGetFromManga(){
-        final MangaListStatus status = mal.getManga(TestProvider.MangaID).getListStatus();
+        final MangaListStatus status = mal.getManga(TestProvider.MangaID, MyAnimeList.ALL_MANGA_FIELDS).getListStatus();
         testStatus(status);
     }
 

--- a/src/test/java/com/kttdevelopment/myanimelist/MangaTests/TestMangaRank.java
+++ b/src/test/java/com/kttdevelopment/myanimelist/MangaTests/TestMangaRank.java
@@ -23,6 +23,7 @@ public class TestMangaRank {
         final List<MangaRanking> ranking =
             mal.getMangaRanking(MangaRankingType.Manga)
                 .withLimit(1)
+                .withFields(MyAnimeList.ALL_MANGA_FIELDS)
                 .search();
         final MangaRanking first = ranking.get(0);
         Assertions.assertEquals(1,first.getRanking());

--- a/src/test/java/com/kttdevelopment/myanimelist/MangaTests/TestMangaSearch.java
+++ b/src/test/java/com/kttdevelopment/myanimelist/MangaTests/TestMangaSearch.java
@@ -72,14 +72,4 @@ public class TestMangaSearch {
         }
     }
 
-    @Test @DisplayName("#6 - Limit") @Disabled
-    public void testOverLimit(){
-        Assertions.assertNotNull(mal.getManga().withLimit(200).search());
-    }
-
-    @Test @DisplayName("#6 - Offset") @Disabled
-    public void testZeroOffset(){
-        Assertions.assertNotNull(mal.getManga().withOffset(0).search());
-    }
-
 }

--- a/src/test/java/com/kttdevelopment/myanimelist/MangaTests/TestUserMangaListing.java
+++ b/src/test/java/com/kttdevelopment/myanimelist/MangaTests/TestUserMangaListing.java
@@ -24,6 +24,7 @@ public class TestUserMangaListing {
             mal.getUserMangaListing()
                .withStatus(MangaStatus.PlanToRead)
                .withLimit(1)
+               .withField(MyAnimeList.ALL_MANGA_FIELDS)
                .search();
         Assertions.assertEquals(MangaStatus.PlanToRead, list.get(0).getStatus());
     }
@@ -34,6 +35,7 @@ public class TestUserMangaListing {
             mal.getUserMangaListing()
                .sortBy(MangaSort.UpdatedAt)
                .withLimit(2)
+               .withField(MyAnimeList.ALL_MANGA_FIELDS)
                .search();
         Assertions.assertTrue(list.get(0).getUpdatedAt() > list.get(1).getUpdatedAt());
     }

--- a/src/test/java/com/kttdevelopment/myanimelist/UserTests/TestUser.java
+++ b/src/test/java/com/kttdevelopment/myanimelist/UserTests/TestUser.java
@@ -15,7 +15,7 @@ public class TestUser {
     @BeforeAll
     public static void beforeAll(){
         mal = TestProvider.getMyAnimeList();
-        user = mal.getMyself();
+        user = mal.getMyself(MyAnimeList.ALL_USER_FIELDS);
     }
 
     @SuppressWarnings("SpellCheckingInspection")


### PR DESCRIPTION
By default the API will now return the bare minimum fields instead of all fields. This is in order to match the MAL API documentation.

- Closes #34 
- Minor bug fixes regarding fields
- Adds static ALL fields
- Clarifies documentation for field parameter
- Closes #36 